### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A systematic reasoning MCP server implementation for Claude Desktop with beam search and thought evaluation capabilities.
 
+<a href="https://glama.ai/mcp/servers/g71nwrrr8e"><img width="380" height="200" src="https://glama.ai/mcp/servers/g71nwrrr8e/badge" alt="mcp-reasoner MCP server" /></a>
+
 ## Features
 
 - Beam search with configurable width


### PR DESCRIPTION
This PR adds a badge for the mcp-reasoner server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/g71nwrrr8e"><img width="380" height="200" src="https://glama.ai/mcp/servers/g71nwrrr8e/badge" alt="mcp-reasoner MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.